### PR TITLE
Fix a bug that causes crash when saving a untitled file

### DIFF
--- a/lib/vue-autocompile.coffee
+++ b/lib/vue-autocompile.coffee
@@ -32,6 +32,7 @@ module.exports = new class VueAutocompile
     @activeEditor = atom.workspace.getActiveTextEditor()
     return unless @activeEditor?
     path = @activeEditor.getURI()
+    return unless path?
     return unless path.match /.*\.vue$/
     @debug "is vue!"
     text = @activeEditor.getText()


### PR DESCRIPTION
when one creates a new file "untitled" and then press "cmd+s" to save it, @activeEditor.getURI() will return an undefined, so it should be checked before running regex test
